### PR TITLE
updated provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "3.0.1-rc8"
+      version = "3.0.2-rc03"
     }
   }
 }


### PR DESCRIPTION
Bumping terraform proxmox provider version from 3.0.1-rc8 to 3.0.2-rc03