### PR TITLE
Upgrade Proxmox provider to v3.0.2-rc03 and refactor module syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,135 @@
-<!-- BEGIN_TF_DOCS -->
+# Proxmox VM Terraform Module
+
+A Terraform module for creating and managing Proxmox VMs using the Proxmox provider.
+
+## Features
+
+- Create single or multiple VMs
+- Support for cloning from existing templates
+- Cloud-init configuration
+- Flexible CPU and memory allocation
+- Network configuration
+- Storage management
+- Predefined instance sizes (xsmall, small, medium, large, xlarge)
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_proxmox"></a> [proxmox](#requirement\_proxmox) | 3.0.2-rc03 |
+- Terraform >= 0.13.0
+- Proxmox provider >= 3.0.2-rc03
 
-## Providers
+## Provider Configuration
 
-| Name | Version |
-|------|---------|
-| <a name="provider_proxmox"></a> [proxmox](#provider\_proxmox) | 3.0.2-rc03 |
+```hcl
+provider "proxmox" {
+  pm_api_url          = "https://your-proxmox-host:8006/api2/json"
+  pm_api_token_id     = "your-token-id"
+  pm_api_token_secret = "your-token-secret"
+  pm_tls_insecure     = true  # Set to false for production
+}
+```
 
-## Modules
+## Usage
 
-No modules.
+### Basic Example
 
-## Resources
+```hcl
+module "example_vm" {
+  source = "./modules/pvevm"
+  
+  name         = "example-vm"
+  target_node  = "pve-node-1"
+  clone        = "ubuntu-template"
+  storage      = "local-lvm"
+  instance_size = "medium"
+  
+  # Network configuration
+  bridge = "vmbr0"
+  model  = "virtio"
+  
+  # Cloud-init configuration
+  ciuser     = "ubuntu"
+  cipassword = "your-password"
+  sshkeys    = file("~/.ssh/id_rsa.pub")
+}
+```
 
-| Name | Type |
-|------|------|
-| [proxmox_vm_qemu.pvevm](https://registry.terraform.io/providers/Telmate/proxmox/3.0.2-rc03/docs/resources/vm_qemu) | resource |
+### Advanced CPU Configuration
+
+```hcl
+module "custom_vm" {
+  source = "./modules/pvevm"
+  
+  name         = "custom-vm"
+  target_node  = "pve-node-2"
+  clone        = "debian-template"
+  storage      = "local-lvm"
+  
+  # Custom CPU configuration
+  cpu = {
+    cores   = 8
+    sockets = 2
+    vcores  = 16
+  }
+  
+  memory = 32768
+  size   = "100G"
+  
+  # ... other configuration
+}
+```
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent"></a> [agent](#input\_agent) | Qemu Guest Agent Enabled or not enabled=1 | `number` | `1` | no |
-| <a name="input_bridge"></a> [bridge](#input\_bridge) | Map of tags to add to the VM. Stored as JSON in the Notes field in Proxmox. | `string` | `"vmbr0"` | no |
-| <a name="input_cipassword"></a> [cipassword](#input\_cipassword) | Override the default cloud-init user's password | `string` | n/a | yes |
-| <a name="input_ciuser"></a> [ciuser](#input\_ciuser) | Override the default cloud-init user for provisioning | `string` | n/a | yes |
-| <a name="input_clone"></a> [clone](#input\_clone) | The base VM from which to clone to create the new VM | `string` | n/a | yes |
-| <a name="input_connection"></a> [connection](#input\_connection) | Provisioner connection settings | `map(string)` | <pre>{<br/>  "agent": true,<br/>  "type": "ssh"<br/>}</pre> | no |
-| <a name="input_cores"></a> [cores](#input\_cores) | The number of CPU cores per CPU socket to allocate to the VM | `number` | `null` | no |
-| <a name="input_disks"></a> [disks](#input\_disks) | VM disk config | `list(map(string))` | <pre>[<br/>  {}<br/>]</pre> | no |
-| <a name="input_gateway"></a> [gateway](#input\_gateway) | Gateway IP Address | `string` | `""` | no |
-| <a name="input_id"></a> [id](#input\_id) | New required field proxmox | `number` | `0` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Instance Count | `number` | `1` | no |
-| <a name="input_instance_size"></a> [instance\_size](#input\_instance\_size) | The size of the instance (small, medium, large). If empty, custom values must be provided. | `string` | `""` | no |
-| <a name="input_instance_sizes"></a> [instance\_sizes](#input\_instance\_sizes) | Map of instance sizes with predefined settings | <pre>map(object({<br/>    memory  = number<br/>    cores   = number<br/>    sockets = number<br/>    vcpus   = number<br/>    size    = string<br/>  }))</pre> | <pre>{<br/>  "large": {<br/>    "cores": 8,<br/>    "memory": 16384,<br/>    "size": "40G",<br/>    "sockets": 1,<br/>    "vcpus": 8<br/>  },<br/>  "medium": {<br/>    "cores": 4,<br/>    "memory": 8192,<br/>    "size": "20G",<br/>    "sockets": 1,<br/>    "vcpus": 4<br/>  },<br/>  "small": {<br/>    "cores": 2,<br/>    "memory": 4096,<br/>    "size": "12G",<br/>    "sockets": 1,<br/>    "vcpus": 2<br/>  },<br/>  "xlarge": {<br/>    "cores": 10,<br/>    "memory": 32768,<br/>    "size": "60G",<br/>    "sockets": 1,<br/>    "vcpus": 10<br/>  },<br/>  "xsmall": {<br/>    "cores": 1,<br/>    "memory": 2048,<br/>    "size": "10G",<br/>    "sockets": 1,<br/>    "vcpus": 1<br/>  }<br/>}</pre> | no |
-| <a name="input_ip_addresses"></a> [ip\_addresses](#input\_ip\_addresses) | List of IP addresses with cidr notation | `list(string)` | `[]` | no |
-| <a name="input_ipconfig0"></a> [ipconfig0](#input\_ipconfig0) | The first IP address to assign to the guest. Format: [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>] | `string` | `"ip=dhcp"` | no |
-| <a name="input_ipconfig1"></a> [ipconfig1](#input\_ipconfig1) | The second IP address to assign to the guest. Same format as ipconfig0 | `string` | `null` | no |
-| <a name="input_ipconfig2"></a> [ipconfig2](#input\_ipconfig2) | The third IP address to assign to the guest. Same format as ipconfig0 | `string` | `null` | no |
-| <a name="input_memory"></a> [memory](#input\_memory) | The amount of memory to allocate to the VM in Megabytes | `number` | `null` | no |
-| <a name="input_model"></a> [model](#input\_model) | Network Model | `string` | `"virtio"` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the VM within Proxmox | `string` | n/a | yes |
-| <a name="input_nameserver"></a> [nameserver](#input\_nameserver) | Sets default DNS server for guest | `string` | `null` | no |
-| <a name="input_networks"></a> [networks](#input\_networks) | VM network adapter config | `list(map(string))` | <pre>[<br/>  {}<br/>]</pre> | no |
-| <a name="input_notes"></a> [notes](#input\_notes) | VM notes field that maps to desc | `string` | `"Managed by Terraform."` | no |
-| <a name="input_ostype"></a> [ostype](#input\_ostype) | The OS Type | `string` | `"cloud-init"` | no |
-| <a name="input_pool"></a> [pool](#input\_pool) | The destination resource pool for the new VM | `string` | `null` | no |
-| <a name="input_proxmox_api_token_id"></a> [proxmox\_api\_token\_id](#input\_proxmox\_api\_token\_id) | API Token | `string` | n/a | yes |
-| <a name="input_proxmox_api_token_secret"></a> [proxmox\_api\_token\_secret](#input\_proxmox\_api\_token\_secret) | API Secret | `string` | n/a | yes |
-| <a name="input_proxmox_api_url"></a> [proxmox\_api\_url](#input\_proxmox\_api\_url) | Full Proxmox API URL | `string` | n/a | yes |
-| <a name="input_proxmox_tls_insecure"></a> [proxmox\_tls\_insecure](#input\_proxmox\_tls\_insecure) | Allow Insecure TLS | `bool` | `true` | no |
-| <a name="input_scsihw"></a> [scsihw](#input\_scsihw) | scsi hardware type | `string` | `"virtio-scsi-pci"` | no |
-| <a name="input_searchdomain"></a> [searchdomain](#input\_searchdomain) | Sets default DNS search domain suffix | `string` | `null` | no |
-| <a name="input_serial0"></a> [serial0](#input\_serial0) | serial device in order for console device to work | `number` | `0` | no |
-| <a name="input_size"></a> [size](#input\_size) | Disk Size | `string` | `null` | no |
-| <a name="input_sockets"></a> [sockets](#input\_sockets) | The number of CPU sockets to allocate to the VM | `number` | `null` | no |
-| <a name="input_sshkeys"></a> [sshkeys](#input\_sshkeys) | Newline delimited list of SSH public keys to add to authorized keys file for the cloud-init user | `string` | n/a | yes |
-| <a name="input_storage"></a> [storage](#input\_storage) | Disk Storage Location | `string` | n/a | yes |
-| <a name="input_tag"></a> [tag](#input\_tag) | Vlan ID | `number` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | tags comma seperated | `string` | `""` | no |
-| <a name="input_target_node"></a> [target\_node](#input\_target\_node) | The name of the Proxmox Node on which to place the VM | `string` | `null` | no |
-| <a name="input_target_nodes"></a> [target\_nodes](#input\_target\_nodes) | The name of the Proxmox Node on which to place the VM | `list(string)` | `null` | no |
-| <a name="input_vcpus"></a> [vcpus](#input\_vcpus) | The number of vCPU  to allocate to the VM | `number` | `null` | no |
-| <a name="input_vmid"></a> [vmid](#input\_vmid) | The vm id of the VM within Proxmox. Default is next available | `number` | `0` | no |
+| name | The name of the VM within Proxmox | `string` | n/a | yes |
+| target_node | The name of the Proxmox Node on which to place the VM | `string` | `null` | no |
+| clone | The base VM from which to clone to create the new VM | `string` | n/a | yes |
+| storage | Disk Storage Location | `string` | n/a | yes |
+| instance_size | The size of the instance (xsmall, small, medium, large, xlarge) | `string` | `""` | no |
+| cpu | CPU configuration block | `object` | `null` | no |
+| memory | The amount of memory to allocate to the VM in Megabytes | `number` | `null` | no |
+| size | Disk Size | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_vm_id"></a> [vm\_id](#output\_vm\_id) | VM IDS |
-| <a name="output_vm_ip"></a> [vm\_ip](#output\_vm\_ip) | VM IP Addresses |
-| <a name="output_vm_memory"></a> [vm\_memory](#output\_vm\_memory) | VM Memory |
-| <a name="output_vm_name"></a> [vm\_name](#output\_vm\_name) | VM NAMES |
-| <a name="output_vm_nameserver"></a> [vm\_nameserver](#output\_vm\_nameserver) | VM Nameservers |
-| <a name="output_vm_notes"></a> [vm\_notes](#output\_vm\_notes) | VM Notes |
-| <a name="output_vm_tags"></a> [vm\_tags](#output\_vm\_tags) | VM Tags |
-| <a name="output_vm_vcpus"></a> [vm\_vcpus](#output\_vm\_vcpus) | VM VCPUS |
-<!-- END_TF_DOCS -->
+| vm_ip | List of VM IP addresses |
+| vm_name | List of VM names |
+| vm_id | List of VM IDs |
+| vm_vcpus | List of VM vCPU counts |
+| vm_memory | List of VM memory allocations |
+| vm_notes | List of VM descriptions/notes |
+| vm_tags | List of VM tags |
+
+## Instance Sizes
+
+The module provides predefined instance sizes for quick deployment:
+
+| Size | Memory | Cores | Sockets | vCores | Disk |
+|------|--------|-------|---------|--------|------|
+| xsmall | 2GB | 1 | 1 | 1 | 10GB |
+| small | 4GB | 2 | 1 | 2 | 12GB |
+| medium | 8GB | 4 | 1 | 4 | 20GB |
+| large | 16GB | 8 | 1 | 8 | 40GB |
+| xlarge | 32GB | 10 | 1 | 10 | 60GB |
+
+## Recent Changes
+
+### v3.0.2-rc03 Upgrade
+
+This module has been updated to use Proxmox provider v3.0.2-rc03 with the following changes:
+
+1. **Provider Version**: Updated from `3.0.1-rc8` to `3.0.2-rc03`
+2. **Description Field**: `desc` parameter changed to `description`
+3. **CPU Configuration**: Individual `cores`, `sockets`, and `vcpus` parameters replaced with a `cpu` block containing:
+   - `cores`: Number of CPU cores per socket
+   - `sockets`: Number of CPU sockets
+   - `vcores`: Total number of virtual CPUs
+
+The module maintains backward compatibility by still supporting the old individual parameters.
+
+## License
+
+This module is licensed under the MIT License.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,150 @@
+# Proxmox VM Module Examples
+
+This module has been updated to use Proxmox provider v3.0.2-rc03 with improved syntax.
+
+## Basic Usage
+
+```hcl
+module "example_vm" {
+  source = "../../modules/pvevm"
+  
+  name         = "example-vm"
+  target_node  = "pve-node-1"
+  clone        = "ubuntu-template"
+  storage      = "local-lvm"
+  
+  # Using predefined instance size
+  instance_size = "medium"
+  
+  # Network configuration
+  bridge = "vmbr0"
+  model  = "virtio"
+  
+  # Cloud-init configuration
+  ciuser     = "ubuntu"
+  cipassword = "your-password"
+  sshkeys    = file("~/.ssh/id_rsa.pub")
+}
+```
+
+## Advanced Usage with Custom CPU Configuration
+
+```hcl
+module "custom_vm" {
+  source = "../../modules/pvevm"
+  
+  name         = "custom-vm"
+  target_node  = "pve-node-2"
+  clone        = "debian-template"
+  storage      = "local-lvm"
+  
+  # Custom CPU configuration using the new cpu block
+  cpu = {
+    cores   = 8
+    sockets = 2
+    vcores  = 16
+  }
+  
+  # Custom memory
+  memory = 32768
+  
+  # Custom disk size
+  size = "100G"
+  
+  # Network configuration
+  bridge = "vmbr0"
+  model  = "virtio"
+  
+  # Cloud-init configuration
+  ciuser     = "debian"
+  cipassword = "your-password"
+  sshkeys    = file("~/.ssh/id_rsa.pub")
+}
+```
+
+## Multiple Instances
+
+```hcl
+module "cluster_vms" {
+  source = "../../modules/pvevm"
+  
+  name           = "cluster-node"
+  instance_count = 3
+  target_node    = "pve-node-1"
+  clone          = "ubuntu-template"
+  storage        = "local-lvm"
+  
+  # All instances will use the same configuration
+  instance_size = "large"
+  
+  # Network configuration
+  bridge = "vmbr0"
+  model  = "virtio"
+  
+  # Cloud-init configuration
+  ciuser     = "ubuntu"
+  cipassword = "your-password"
+  sshkeys    = file("~/.ssh/id_rsa.pub")
+}
+```
+
+## Migration from Old Syntax
+
+### Before (Provider v3.0.1-rc8 and earlier):
+```hcl
+module "old_vm" {
+  source = "../../modules/pvevm"
+  
+  name     = "old-vm"
+  cores    = 4
+  sockets  = 1
+  vcpus    = 4
+  memory   = 8192
+  # ... other configuration
+}
+```
+
+### After (Provider v3.0.2-rc03):
+```hcl
+module "new_vm" {
+  source = "../../modules/pvevm"
+  
+  name = "new-vm"
+  
+  # Option 1: Use predefined instance size
+  instance_size = "medium"
+  
+  # Option 2: Use custom CPU configuration
+  cpu = {
+    cores   = 4
+    sockets = 1
+    vcores  = 4
+  }
+  
+  memory = 8192
+  # ... other configuration
+}
+```
+
+## Key Changes in v3.0.2-rc03
+
+1. **Provider Version**: Updated from `3.0.1-rc8` to `3.0.2-rc03`
+2. **Description Field**: `desc` parameter changed to `description`
+3. **CPU Configuration**: Individual `cores`, `sockets`, and `vcpus` parameters replaced with a `cpu` block containing:
+   - `cores`: Number of CPU cores per socket
+   - `sockets`: Number of CPU sockets
+   - `vcores`: Total number of virtual CPUs
+4. **Backward Compatibility**: The module still supports the old individual parameters for backward compatibility
+
+## Outputs
+
+The module provides the following outputs:
+
+- `vm_ip`: List of VM IP addresses
+- `vm_nameserver`: List of VM nameservers
+- `vm_name`: List of VM names
+- `vm_id`: List of VM IDs
+- `vm_vcpus`: List of VM vCPU counts
+- `vm_memory`: List of VM memory allocations
+- `vm_notes`: List of VM descriptions/notes
+- `vm_tags`: List of VM tags

--- a/main.tf
+++ b/main.tf
@@ -2,15 +2,19 @@ resource "proxmox_vm_qemu" "pvevm" {
   count        = var.instance_count
   name         = var.name != "" && var.instance_count > 1 ? "${var.name}${count.index + 1}" : var.name
   vmid         = (var.instance_count > 1 ? (var.vmid == 0 ? 0 : var.vmid + count.index) : var.vmid)
-  desc         = var.notes
+  description  = var.notes
   target_node  = var.target_node
   target_nodes = var.target_nodes
   clone        = var.clone
   memory       = coalesce(var.memory, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).memory)
   scsihw       = var.scsihw
-  cores        = coalesce(var.cores, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).cores)
-  sockets      = coalesce(var.sockets, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).sockets)
-  vcpus        = coalesce(var.vcpus, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).vcpus)
+  
+  cpu {
+    cores   = var.cpu != null ? var.cpu.cores : coalesce(var.cores, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).cores)
+    sockets = var.cpu != null ? var.cpu.sockets : coalesce(var.sockets, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).sockets)
+    vcores  = var.cpu != null ? var.cpu.vcores : coalesce(var.vcpus, lookup(var.instance_sizes, var.instance_size, var.instance_sizes["small"]).vcores)
+  }
+  
   agent        = var.agent
   tags         = var.tags
   serial {

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "vm_memory" {
 
 output "vm_notes" {
   description = "VM Notes"
-  value       = [for vm in proxmox_vm_qemu.pvevm : vm.desc]
+  value       = [for vm in proxmox_vm_qemu.pvevm : vm.description]
 }
 
 output "vm_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -261,20 +261,30 @@ variable "instance_size" {
   default     = ""
 }
 
+variable "cpu" {
+  description = "CPU configuration block"
+  type = object({
+    cores   = number
+    sockets = number
+    vcores  = number
+  })
+  default = null
+}
+
 variable "instance_sizes" {
   description = "Map of instance sizes with predefined settings"
   type = map(object({
     memory  = number
     cores   = number
     sockets = number
-    vcpus   = number
+    vcores  = number
     size    = string
   }))
   default = {
-    xsmall = { memory = 2048, cores = 1, sockets = 1, vcpus = 1, size = "10G" }
-    small  = { memory = 4096, cores = 2, sockets = 1, vcpus = 2, size = "12G" }
-    medium = { memory = 8192, cores = 4, sockets = 1, vcpus = 4, size = "20G" }
-    large  = { memory = 16384, cores = 8, sockets = 1, vcpus = 8, size = "40G" }
-    xlarge = { memory = 32768, cores = 10, sockets = 1, vcpus = 10, size = "60G" }
+    xsmall = { memory = 2048, cores = 1, sockets = 1, vcores = 1, size = "10G" }
+    small  = { memory = 4096, cores = 2, sockets = 1, vcores = 2, size = "12G" }
+    medium = { memory = 8192, cores = 4, sockets = 1, vcores = 4, size = "20G" }
+    large  = { memory = 16384, cores = 8, sockets = 1, vcores = 8, size = "40G" }
+    xlarge = { memory = 32768, cores = 10, sockets = 1, vcores = 10, size = "60G" }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "3.0.1-rc8"
+      version = "3.0.2-rc03"
     }
   }
 }


### PR DESCRIPTION
- Update provider version from 3.0.1-rc8 to 3.0.2-rc03
- Change 'desc' parameter to 'description'
- Replace individual CPU parameters with 'cpu' block containing cores, sockets, vcores
- Update instance_sizes to use vcores instead of vcpus
- Maintain backward compatibility with old individual parameters
- Update documentation and examples
- Update outputs to reference vm.description instead of vm.desc