### PR TITLE
feat: boot/pxe/iso support

### DIFF
--- a/examples/multiple-networks-disks.md
+++ b/examples/multiple-networks-disks.md
@@ -216,6 +216,121 @@ module "simple_vm" {
 }
 ```
 
+## Example 5: ISO Boot - Create VM from ISO Image
+
+```hcl
+module "iso_boot_vm" {
+  source = "github.com/valueiron/pvevm.git?ref=feature/expansion"
+  
+  proxmox_api_url          = var.pm_api_url
+  proxmox_api_token_id     = var.pm_api_token_id
+  proxmox_api_token_secret = var.pm_api_token_secret
+  
+  name         = "iso-install-vm"
+  vmid         = 204
+  target_node  = "pve1"
+  storage      = "local-lvm"
+  instance_size = "medium"
+  
+  # ISO boot configuration
+  iso  = "local:iso/ubuntu-22.04-server-amd64.iso"
+  boot = "order=ide2;scsi0"  # Boot from CD-ROM first, then hard disk
+  
+  # Network configuration
+  bridge = "vmbr0"
+  model  = "virtio"
+  tag    = 150
+  
+  # Note: When using ISO, clone, ciuser, cipassword, and sshkeys are NOT required
+  # Cloud-init disk (scsi1) is automatically skipped when ISO is specified
+}
+```
+
+## Example 6: PXE Boot - Network Boot Configuration
+
+```hcl
+module "pxe_boot_vm" {
+  source = "github.com/valueiron/pvevm.git?ref=feature/expansion"
+  
+  proxmox_api_url          = var.pm_api_url
+  proxmox_api_token_id     = var.pm_api_token_id
+  proxmox_api_token_secret = var.pm_api_token_secret
+  
+  name         = "pxe-install-vm"
+  vmid         = 205
+  target_node  = "pve2"
+  storage      = "local-lvm"
+  instance_size = "large"
+  
+  # PXE boot configuration
+  pxe  = true
+  boot = "order=net0;scsi0"  # Boot from network first, then hard disk
+  
+  # Network configuration (required for PXE)
+  bridge = "vmbr0"
+  model  = "virtio"
+  tag    = 100  # PXE network VLAN
+  
+  # Note: When using PXE, clone, ciuser, cipassword, and sshkeys are NOT required
+  # Cloud-init disk (scsi1) is automatically skipped when ISO is not specified
+}
+```
+
+## Example 7: ISO Boot with Custom Boot Order and Additional Disks
+
+```hcl
+module "iso_custom_vm" {
+  source = "github.com/valueiron/pvevm.git?ref=feature/expansion"
+  
+  proxmox_api_url          = var.pm_api_url
+  proxmox_api_token_id     = var.pm_api_token_id
+  proxmox_api_token_secret = var.pm_api_token_secret
+  
+  name         = "custom-iso-vm"
+  vmid         = 206
+  target_node  = "pve1"
+  storage      = "local-lvm"
+  
+  # Custom CPU and memory
+  cpu = {
+    cores   = 4
+    sockets = 1
+    vcores  = 4
+  }
+  memory = 8192  # 8GB
+  
+  # ISO boot with custom boot order
+  iso  = "local:iso/windows-server-2022.iso"
+  boot = "order=ide2;scsi0;net0"  # CD-ROM, then disk, then network
+  
+  # Multiple network interfaces
+  networks = [
+    {
+      id     = 0
+      bridge = "vmbr0"
+      tag    = 100
+    },
+    {
+      id     = 1
+      bridge = "vmbr0"
+      tag    = 200
+    }
+  ]
+  
+  # Additional storage for installation
+  additional_disks = [
+    {
+      type    = "scsi"
+      slot    = 2
+      storage = "nvme2-ceph"
+      size    = "500G"
+    }
+  ]
+  
+  # Note: No cloud-init configuration needed for ISO boot
+}
+```
+
 ## Network Configuration Options
 
 | Parameter | Description | Type | Default |
@@ -241,22 +356,54 @@ module "simple_vm" {
 
 **Note:** In Proxmox provider v3.0.2-rc03, only `type`, `slot`, `storage`, and `size` are supported for additional disks. Advanced options like `ssd`, `cache`, `iothread`, etc. are not available in the disk block.
 
+## Boot Configuration Options
+
+| Parameter | Description | Type | Default | Required |
+|-----------|-------------|------|---------|----------|
+| boot | Boot order specification (e.g., "order=scsi0;net0" or "order=ide2;scsi0") | string | null | no |
+| iso | ISO file location in Proxmox storage format (e.g., "local:iso/ubuntu-22.04.iso") | string | null | no |
+| pxe | Enable PXE boot via network interface | bool | null | no |
+
+**Boot Order Characters:**
+- `c` = hard disk (scsi0)
+- `d` = CD-ROM (ide2)
+- `n` = network (net0)
+
+**Boot Order Priority:**
+1. If `boot` is explicitly set, use that value
+2. If `iso` is set and `boot` is null, defaults to `"order=ide2;scsi0"` (CD-ROM first)
+3. If `pxe` is true and neither `boot` nor `iso` are set, defaults to `"order=net0"` (network)
+4. Otherwise, Proxmox uses default boot order
+
 ## Important Notes
 
 1. **Disk Slots**: 
    - scsi0 is reserved for the primary disk (from template/instance_size)
-   - scsi1 is reserved for cloudinit
+   - scsi1 is reserved for cloudinit (only created when cloning from template, not when using ISO)
    - scsi2-scsi5 are available for additional disks
 
 2. **Backward Compatibility**: 
    - If you don't specify `networks`, the module uses the original single network variables (`bridge`, `model`, `tag`)
-   - If you don't specify `additional_disks`, only the primary disk and cloudinit disk are created
+   - If you don't specify `additional_disks`, only the primary disk and cloudinit disk are created (when cloning)
 
 3. **Network Fallback**: 
    - Leave `networks = []` to use the original single network configuration
    - Specify `networks` to override and use multiple networks
 
-4. **Performance Tips**:
+4. **ISO Boot Behavior**:
+   - When `iso` is specified, the VM is created from scratch (not cloned)
+   - `clone`, `ciuser`, `cipassword`, and `sshkeys` are NOT required when using ISO
+   - Cloud-init disk (scsi1) is automatically skipped when ISO is set
+   - Boot order defaults to `order=ide2;scsi0` (CD-ROM first) if not explicitly set
+   - IDE2 CD-ROM device is automatically configured with the specified ISO
+
+5. **PXE Boot Behavior**:
+   - When `pxe = true`, the VM boots from the network interface
+   - `clone`, `ciuser`, `cipassword`, and `sshkeys` are NOT required when using PXE
+   - Boot order defaults to `order=net0` if not explicitly set
+   - Ensure network interface is properly configured for PXE boot
+
+6. **Performance Tips**:
    - Set appropriate `rate` limits on network interfaces if needed
    - Use multiple network interfaces for different traffic types (management, data, storage)
    - Choose appropriate storage backends (nvme2-ceph for performance, local-lvm for local storage)

--- a/variables.tf
+++ b/variables.tf
@@ -40,8 +40,9 @@ variable "target_nodes" {
 }
 
 variable "clone" {
-  description = "Source template or VM name to clone"
+  description = "Source template or VM name to clone. Not required when ISO is specified."
   type        = string
+  default     = null
 }
 
 variable "memory" {
@@ -197,14 +198,16 @@ variable "ostype" {
 }
 
 variable "ciuser" {
-  description = "Cloud-init default user"
+  description = "Cloud-init default user. Not required when ISO is specified."
   type        = string
+  default     = null
 }
 
 variable "cipassword" {
-  description = "Cloud-init user password"
+  description = "Cloud-init user password. Not required when ISO is specified."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "searchdomain" {
@@ -220,8 +223,9 @@ variable "nameserver" {
 }
 
 variable "sshkeys" {
-  description = "Newline-delimited SSH public keys for the cloud-init user"
+  description = "Newline-delimited SSH public keys for the cloud-init user. Not required when ISO is specified."
   type        = string
+  default     = null
 }
 
 variable "ipconfig0" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,23 @@ variable "size" {
   default     = null
 }
 
+variable "boot" {
+  description = "Boot order specification (e.g., 'order=scsi0;net0' or 'order=ide2;scsi0'). If not specified and ISO is provided, defaults to booting from CD-ROM first."
+  type        = string
+  default     = null
+}
+
+variable "iso" {
+  description = "ISO file location in Proxmox storage format (e.g., 'local:iso/ubuntu-22.04.iso'). When specified, automatically configures IDE2 as a CD-ROM device."
+  type        = string
+  default     = null
+}
+
+variable "pxe" {
+  description = "Enable PXE boot via network interface. When true, sets boot order to network if boot order is not explicitly specified."
+  type        = bool
+  default     = null
+}
 
 ################################# Multiple Network and Disk Support
 variable "networks" {


### PR DESCRIPTION
Support boot,pxe, and iso variables

- Enables the ability to set boot order
- Enables PXE boot
- Dynamically creates idew cdrom when iso is specified
- Maintains backwards compatibility
- Dynamic cloud init disk so that it's not specified when iso variable is set
- Sets defaults of null for cloud init settings when not needed. When booting from ISO. Mainly to support Talos and Vyos