### PR TITLE
chore: bump Telmate/proxmox provider to v3.0.2-rc07

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "3.0.2-rc03"
+      version = "3.0.2-rc07"
     }
   }
 }


### PR DESCRIPTION
## Summary

Bumps the `Telmate/proxmox` Terraform provider from `3.0.2-rc03` to `3.0.2-rc07`.

## Changes in rc03 → rc07

**rc04**
- Fixed default permissions incompatibility with Proxmox VE 9 (`VM.Monitor` removed from required permissions)
- Added handling for delete with protected guests
- Added LXC mount support

**rc05**
- Fixed clone using wrong node when identical templates exist on multiple nodes
- Fixed `vmid` validation (can no longer be set to 0)
- Added experimental `proxmox_lxc_guest` resource
- Added `automatic_reboot = false` error behaviour

**rc06**
- Fixed HA removal logic
- Fixed nil pointer panic when getting config
- Fixed provider error/halt when resource is removed outside Terraform
- Added `Pool.Audit` to required permissions

**rc07**
- Fixed state refresh when `tags` are empty (directly relevant — this module normalises tags)
- Fixed bug where a Qemu guest could not be updated
- Fixed missing `ide3` slot validation in flat disk schema

## Code changes

No resource attribute changes required. All rc03→rc07 releases are bug fixes and LXC additions with no breaking changes to `proxmox_vm_qemu`.